### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ReduxISU/quantumsolver/security/code-scanning/1](https://github.com/ReduxISU/quantumsolver/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (currently there is one job, `build`). For this workflow, the minimal required permission is `contents: read` (needed for `actions/checkout` to read repository contents). No functional behavior changes are required.

**File to change:** `.github/workflows/main.yaml`  
**Region to change:** after the `on:` trigger block and before `jobs:`.  
**What to add:**  
```yaml
permissions:
  contents: read
```
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
